### PR TITLE
fix: 页面宽度切换时，header菜单闪动

### DIFF
--- a/components/Header/index.vue
+++ b/components/Header/index.vue
@@ -1,8 +1,13 @@
 <script setup lang="ts">
+import { breakpointsTailwind } from '@vueuse/core'
 import { Ref } from 'vue'
 
 const { data } = await useFetch('/api/global/nav')
 const route = useRoute()
+
+const breakpoints = useBreakpoints(breakpointsTailwind)
+
+const mdAndLarger = breakpoints.greaterOrEqual('md')
 
 // 当前激活的导航项
 const activeNav = computed(() => {
@@ -58,6 +63,13 @@ const isHeaderVisible = inject('isHeaderVisible') as Ref<boolean>
     </header>
   </div>
 </template>
+
+<style>
+.mobile-menu-enter-active,
+.mobile-menu-leave-active {
+  transition: all 0.3s;
+}
+</style>
 
 <style scoped lang="scss">
 .header-wrapper {
@@ -116,6 +128,7 @@ header {
 
       &.mobile-shown .icon {
         @apply rotate-180;
+        @apply fill-primary;
       }
     }
 
@@ -129,11 +142,9 @@ header {
         @apply absolute top-49px left-16px p-2 h-auto;
         @apply border-1 border-gray-200 dark:border-[#494949] rounded-md;
         @apply shadow-xl shadow-black/10 dark:shadow-white/10;
-        @apply transform-gpu transition origin-top;
-        @apply -translate-x-1/2;
+        @apply transform-gpu -translate-x-1/2;
         @apply bg-white dark:bg-[#121212];
-        @apply scale-y-50 opacity-0;
-        @apply pointer-events-none;
+        @apply hidden;
         &:deep(.nav-item-wrapper) {
           @apply px-13;
         }
@@ -141,8 +152,7 @@ header {
           @apply h-11;
         }
         &.mobile-shown {
-          @apply scale-y-100 opacity-100;
-          @apply pointer-events-auto;
+          @apply block;
         }
       }
 

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -56,7 +56,7 @@ const isHeaderVisible = inject('isHeaderVisible') as Ref<boolean>
     @apply w-full h-11 flex justify-center;
     @apply bg-white dark:bg-[#121212];
     @apply border-b-1 border-gray-100 dark:border-[#494949];
-    @apply fixed top-0 z-11;
+    @apply fixed top-0 z-9;
     @apply transform-gpu transition-transform;
     @apply shadow-sm shadow-black/5 dark:shadow-white/5;
 


### PR DESCRIPTION
更改：
1. 修改了main header和子页面header的层级关系
2. 修复了宽度改变时，菜单闪烁的问题